### PR TITLE
Add 'sectionflag' directive

### DIFF
--- a/XrAsm/Frontend/AsmParse.jkl
+++ b/XrAsm/Frontend/AsmParse.jkl
@@ -1059,6 +1059,85 @@ FN (AsmDirectiveF) AsmParseSection (
     AsmCurrentSection = section
     AsmLastLabel = NULLPTR
 END
+FN (AsmDirectiveF) AsmParseSectionFlag (
+    IN errtoken : ^LexToken,
+)
+
+    // Parse the sectionflag directive, which sets (or unsets) a section flag.
+
+    IF AsmCurrentSection == NULLPTR THEN
+        LexError ( errtoken, "'sectionflag' may not be used outside of a section\n" )
+    END
+
+    // Grammar:
+    //  sectionflag = "sectionflag" { ["~"]flag "," } [ ["~"]flag ];
+    //  flag = "zero" | "code" | "paged" | "map";
+
+    // Example:
+    //  .sectionflag code, ~paged
+
+    token : LexToken
+
+    LexGetToken ( &token )
+
+    WHILE TRUE DO
+        IF token.Type == TOKEN_NEWLINE THEN
+            BREAK
+        END
+
+        // Check if we're unsetting a flag, indicated with ~.
+
+        unset := FALSE
+
+        IF token.Type == TOKEN_OPER AND
+            token.Subtype == TOKEN_BITNOT THEN
+
+            unset = TRUE
+
+            LexGetToken ( &token )
+        END
+
+        IF token.Type != TOKEN_IDENTIFIER THEN
+            LexError ( &token, "Expected identifier\n" )
+        END
+
+        symbol := CAST token.Payload TO ^LexSymbol
+
+        name := symbol^.Name
+
+        flag : UWORD
+
+        IF TlCompareStringWithMax ( name, "zero", 4 ) == 0 THEN
+            flag = XLO_SECTION_ZERO
+
+        ELSEIF TlCompareStringWithMax ( name, "code", 4 ) == 0 THEN
+            flag = XLO_SECTION_CODE
+
+        ELSEIF TlCompareStringWithMax ( name, "paged", 5 ) == 0 THEN
+            flag = XLO_SECTION_PAGED
+
+        ELSEIF TlCompareStringWithMax ( name, "map", 3 ) == 0 THEN
+            flag = XLO_SECTION_MAP
+
+        ELSE
+            LexError ( &token, "Expected 'zero', 'code', 'paged', or 'map'\n" )
+        END
+
+        IF unset THEN
+            AsmCurrentSection^.SectionFlags &= ~flag
+        ELSE
+            AsmCurrentSection^.SectionFlags |= flag
+        END
+
+        LexGetToken ( &token )
+
+        IF token.Type != TOKEN_COMMA THEN
+            BREAK
+        END
+
+        LexGetToken ( &token )
+    END
+END
 
 #MACRO AsmCheckExprIfZero ( expr ) [
     IF AsmCurrentSection^.SectionFlags & XLO_SECTION_ZERO THEN
@@ -1596,6 +1675,7 @@ FN (AsmDirectiveF) AsmParseAlign (
 END
 
 AsmDirectivesTable : AsmDirectiveF[TOKEN_SUBTYPE_MAX] = {
+    [TOKEN_SECTIONFLAG] = &AsmParseSectionFlag,
     [TOKEN_SECTION] = &AsmParseSection,
     [TOKEN_DB] = &AsmParseDb,
     [TOKEN_DI] = &AsmParseDi,

--- a/XrAsm/Frontend/LexTokenizer.jkl
+++ b/XrAsm/Frontend/LexTokenizer.jkl
@@ -65,6 +65,7 @@ FN LexInitializeConsumer ()
     LexInsertKeyword ( "\n", TOKEN_NEWLINE, 0, 0 )
     LexInsertKeyword ( "=", TOKEN_EQUALS, 0, 0 )
 
+    LexInsertKeyword ( "sectionflag", TOKEN_DIRECTIVE, TOKEN_SECTIONFLAG, 0 )
     LexInsertKeyword ( "section", TOKEN_DIRECTIVE, TOKEN_SECTION, 0 )
     LexInsertKeyword ( "db", TOKEN_DIRECTIVE, TOKEN_DB, 0 )
     LexInsertKeyword ( "di", TOKEN_DIRECTIVE, TOKEN_DI, 0 )

--- a/XrAsm/include/Lexer.hjk
+++ b/XrAsm/include/Lexer.hjk
@@ -38,6 +38,7 @@ END
 ENUM LexTokenSubtype : UBYTE
     TOKEN_SUBTYPE_ANY,
 
+    TOKEN_SECTIONFLAG, // directive
     TOKEN_SECTION,     // directive
     TOKEN_DB,          // directive
     TOKEN_DI,          // directive


### PR DESCRIPTION
Add a `.sectionflag` directive that manually sets or unsets flags in a section.
It takes a list of comma-separated options, which may be `zero`, `code`, `paged`, or `map`. if an option has a `~` before it, this flag is unset (not toggled).
Example:
```c
.section mysection
// default flags are `XLO_SECTION_MAPPED`

.sectionflag paged
// flags are now `XLO_SECTION_MAP | XLO_SECTION_PAGED`

.sectionflag code, ~paged
// flags are now `XLO_SECTION_MAP | XLO_SECTION_CODE`
```