### PR TITLE
Library: Update fox32os jump table addresses

### DIFF
--- a/Library/fox32os/_TlFoxStart.jkl
+++ b/Library/fox32os/_TlFoxStart.jkl
@@ -233,37 +233,19 @@ sleep_task:                jmp [0x00000A2C]
 allocate_memory:           jmp [0x00000B10]
 free_memory:               jmp [0x00000B14]
 
-// window jump table
-new_window:                jmp [0x00000C10]
-destroy_window:            jmp [0x00000C14]
-new_window_event:          jmp [0x00000C18]
-get_next_window_event:     jmp [0x00000C1C]
-draw_title_bar_to_window:  jmp [0x00000C20]
-move_window:               jmp [0x00000C24]
-fill_window:               jmp [0x00000C28]
-get_window_overlay_number: jmp [0x00000C2C]
-start_dragging_window:     jmp [0x00000C30]
-new_messagebox:            jmp [0x00000C34]
-get_active_window_struct:  jmp [0x00000C38]
-set_window_flags:          jmp [0x00000C3C]
-
 // VFS jump table
-open:                      jmp [0x00000D10]
-seek:                      jmp [0x00000D14]
-tell:                      jmp [0x00000D18]
-read:                      jmp [0x00000D1C]
-write:                     jmp [0x00000D20]
-get_size:                  jmp [0x00000D24]
-create:                    jmp [0x00000D28]
-delete:                    jmp [0x00000D2C]
-copy:                      jmp [0x00000D30]
-
-// widget jump table
-draw_widgets_to_window:    jmp [0x00000E10]
-handle_widget_click:       jmp [0x00000E14]
+open:                      jmp [0x00000C10]
+seek:                      jmp [0x00000C14]
+tell:                      jmp [0x00000C18]
+read:                      jmp [0x00000C1C]
+write:                     jmp [0x00000C20]
+get_size:                  jmp [0x00000C24]
+create:                    jmp [0x00000C28]
+delete:                    jmp [0x00000C2C]
+copy:                      jmp [0x00000C30]
 
 // resource jump table
-get_resource:              jmp [0x00000F10]
+get_resource:              jmp [0x00000D10]
 
 // event types
 #DEFINE EVENT_TYPE_BUTTON_CLICK  0x80000000


### PR DESCRIPTION
With the removal of the window manager from the fox32os kernel, the jump table has been shifted around a bit.